### PR TITLE
Add http support, and add url parameter to the client constructor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Gemfile.lock
 .rvmrc
 /pkg
+.buildpath
+.project

--- a/lib/mms/cli.rb
+++ b/lib/mms/cli.rb
@@ -72,7 +72,7 @@ module MMS
 
       # @return [MMS::Agent]
       def agent
-        @client = MMS::Client.new(@config.username, @config.apikey, url=@config.apiurl)
+        @client = MMS::Client.new(@config.username, @config.apikey, @config.apiurl)
         @agent = MMS::Agent.new(client)
       end
 

--- a/lib/mms/cli.rb
+++ b/lib/mms/cli.rb
@@ -23,7 +23,6 @@ module MMS
 
       option ['-a', '--apiurl'], '<string>', 'MMS api url. Full url including version: https://mms.mydomain.tld/api/public/v1.0' do |u|
         @config.apiurl = u
-        puts "apiurl parsed ---->"+@config.apiurl
       end
 
       option ['-v', '--version'], :flag, 'Version' do |v|

--- a/lib/mms/cli.rb
+++ b/lib/mms/cli.rb
@@ -23,6 +23,7 @@ module MMS
 
       option ['-a', '--apiurl'], '<string>', 'MMS api url. Full url including version: https://mms.mydomain.tld/api/public/v1.0' do |u|
         @config.apiurl = u
+        puts "apiurl parsed ---->"+@config.apiurl
       end
 
       option ['-v', '--version'], :flag, 'Version' do |v|
@@ -68,12 +69,11 @@ module MMS
             raise MMS::ConfigError.new("Config option `#{key}` from file `#{config_file}` is not allowed!")
           end
         end
-
       end
 
       # @return [MMS::Agent]
       def agent
-        @client = MMS::Client.new(@config.username, @config.apikey)
+        @client = MMS::Client.new(@config.username, @config.apikey, url=@config.apiurl)
         @agent = MMS::Agent.new(client)
       end
 

--- a/lib/mms/client.rb
+++ b/lib/mms/client.rb
@@ -16,65 +16,36 @@ module MMS
     end
 
     # @param [String] path
-    # @return [Hash]     
+    # @return [Hash]
     def get(path)
-      _get(@url + path, @username, @apikey)
+      method ={
+        :name => "GET",
+        :http_method => Net::HTTP::Get
+      }
+      _request(@url + path, @username, @apikey, nil, method)
     end
 
     # @param [String] path
     # @param [Hash] data
     # @return [Hash]
     def post(path, data)
-      _post(@url + path, data, @username, @apikey)
+      method = {
+        :name => "POST",
+        :http_method => Net::HTTP::Post
+      }
+      _request(@url + path, @username, @apikey, data, method)
     end
 
     private
-    
-    def _get_ssl()
-      return (@url.split(":")[0]=="https")
-    end
-    
+
     # @param [String] path
     # @param [String] username
     # @param [String] password
-    def _get(path, username, password)
-
-      digest_auth = Net::HTTP::DigestAuth.new
-      digest_auth.next_nonce
-
-      uri = URI.parse path
-      uri.user= CGI.escape(username)
-      uri.password= CGI.escape(password)
-
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = _get_ssl
-
-      req = Net::HTTP::Get.new uri.request_uri
-      res = http.request req
-
-      auth = digest_auth.auth_header uri, res['WWW-Authenticate'], 'GET'
-      req = Net::HTTP::Get.new uri.request_uri
-      req.add_field 'Authorization', auth
-
-      response = http.request(req)
-      response_json = JSON.parse(response.body)
-
-      unless response.code == 200 or response_json['error'].nil?
-        msg = "http 'get' error for url `#{url}`"
-        msg = response_json['detail'] unless response_json['detail'].nil?
-
-        raise MMS::AuthError.new(msg, req, response) if response.code == '401'
-        raise MMS::ApiError.new(msg, req, response)
-      end
-
-      (response_json.nil? or response_json['results'].nil?) ? response_json : response_json['results']
-    end
-
-    # @param [String] path
     # @param [Hash] data
-    # @param [String] username
-    # @param [String] password
-    def _post(path, data, username, password)
+    # @param [Hash] method
+    # @return [Hash]
+    def _request(path, username, password, data = nil, method = {})
+
       digest_auth = Net::HTTP::DigestAuth.new
       digest_auth.next_nonce
 
@@ -83,13 +54,12 @@ module MMS
       uri.password= CGI.escape(password)
 
       http = Net::HTTP.new uri.host, uri.port
-      http.use_ssl = _get_ssl
+      http.use_ssl = (uri.scheme == 'https')
 
-      req = Net::HTTP::Post.new uri.request_uri, {'Content-Type' => 'application/json'}
+      req = method[:http_method].new uri.request_uri, {'Content-Type' => 'application/json'}
       res = http.request req
-
-      auth = digest_auth.auth_header uri, res['WWW-Authenticate'], 'POST'
-      req = Net::HTTP::Post.new uri.request_uri, {'Content-Type' => 'application/json'}
+      auth = digest_auth.auth_header uri, res['WWW-Authenticate'], method[:name]
+      req = method[:http_method].new uri.request_uri, {'Content-Type' => 'application/json'}
       req.add_field 'Authorization', auth
       req.body = data.to_json
 

--- a/lib/mms/client.rb
+++ b/lib/mms/client.rb
@@ -16,7 +16,7 @@ module MMS
     end
 
     # @param [String] path
-    # @return [Hash]
+    # @return [Hash]     
     def get(path)
       _get(@url + path, @username, @apikey)
     end
@@ -29,7 +29,11 @@ module MMS
     end
 
     private
-
+    
+    def _get_ssl()
+      return (@url.split(":")[0]=="https")
+    end
+    
     # @param [String] path
     # @param [String] username
     # @param [String] password
@@ -43,7 +47,7 @@ module MMS
       uri.password= CGI.escape(password)
 
       http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = true
+      http.use_ssl = _get_ssl
 
       req = Net::HTTP::Get.new uri.request_uri
       res = http.request req
@@ -79,7 +83,7 @@ module MMS
       uri.password= CGI.escape(password)
 
       http = Net::HTTP.new uri.host, uri.port
-      http.use_ssl = true
+      http.use_ssl = _get_ssl
 
       req = Net::HTTP::Post.new uri.request_uri, {'Content-Type' => 'application/json'}
       res = http.request req


### PR DESCRIPTION
Hi,

I would like to contribute to this project, i already did most of the changes that you refactored in the last month, like json output or subcommands or custom url parsing, but i decided to drop it away, and follow your branch. My plan is to introduce mostly the full features for the API. (I use the on-prem setup of MMS with version 1.5.3 that is why the first step was to make the url passing working and as our test setup is http to make the ssl optional. Next will try to introduce multiversion support for 1.6 and 1.5 MMS API compatible calls. ) I hope we can work together further, any input is very welcomed, and many thanks for creating this project.

This pull request is about to add the http support , i changed a little the client to wrap the protocol out of the url, and if it is not https, turn off the ssl flag. As well added the url parameter as parameter to the client constructor call in the cli implementation.

Regards, 
@t