### PR TITLE
agent.alerts.each end with undefined method `set_group' 

### DIFF
--- a/lib/mms/resource/group.rb
+++ b/lib/mms/resource/group.rb
@@ -38,7 +38,6 @@ module MMS
       @client.get('/groups/' + @id + '/alerts?status=' + status + '&pageNum=' + page.to_s + '&itemsPerPage=' + limit.to_s).each do |alert|
         a = MMS::Resource::Alert.new
         a.set_client(@client)
-        a.set_group(self)
         a.set_data(data)
 
         alert_list.push a

--- a/lib/mms/resource/group.rb
+++ b/lib/mms/resource/group.rb
@@ -60,6 +60,7 @@ module MMS
           c = MMS::Resource::Cluster.new
           c.set_client(@client)
           c.set_data(cluster)
+
           @clusters.push c
         end
       end

--- a/lib/mms/resource/group.rb
+++ b/lib/mms/resource/group.rb
@@ -38,7 +38,7 @@ module MMS
       @client.get('/groups/' + @id + '/alerts?status=' + status + '&pageNum=' + page.to_s + '&itemsPerPage=' + limit.to_s).each do |alert|
         a = MMS::Resource::Alert.new
         a.set_client(@client)
-        a.set_data(data)
+        a.set_data(alert)
 
         alert_list.push a
       end

--- a/lib/mms/version.rb
+++ b/lib/mms/version.rb
@@ -1,3 +1,3 @@
 module MMS
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end


### PR DESCRIPTION
Hello,

I try get all alert messages from our local mms service and get an undefined method `set_group' error.
It looks like this method is not available in MMS::Resource::Alert class.

kind regards
Eduard


Ruby code:

client = MMS::Client.new("#{mms_user}", "#{mms_user_api_key}","http://mms-dev/api/public/v1.0")
agent = MMS::Agent.new(client)

agent.alerts.each do |alert|
    alert.ack('now')
end

Output:
[36, 45] in .rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/resource/group.rb
   36:     def alerts(page = 1, limit = 1000, status = 'OPEN')
   37:       alert_list = []
   38:       @client.get('/groups/' + @id + '/alerts?status=' + status + '&pageNum=' + page.to_s + '&itemsPerPage=' + limit.to_s).each do |alert|
   39:         a = MMS::Resource::Alert.new
   40:         byebug
=> 41:         a.set_client(@client)
   42:         a.set_group(self)
   43:         a.set_data(data)
   44: 
   45:         alert_list.push a
(byebug) a.methods
[:name, :name=, :type_name, :type_name=, :event_type_name, :event_type_name=, :status, :status=, :acknowledged_until, :acknowledged_until=, :created, :created=, :updated, :updated=, :resolved, :resolved=, :last_notified, :last_notified=, :current_value, :current_value=, :group, :ack, :table_row, :table_section, :id, :id=, :data, :data=, :client, :client=, :set_client, :set_data, :from_hash, :to_hash, :_load, :invalidate_cache, :psych_to_yaml, :to_yaml, :to_yaml_properties, :pretty_print, :pretty_print_cycle, :pretty_print_instance_variables, :pretty_print_inspect, :to_json, :nil?, :===, :=~, :!~, :eql?, :hash, :<=>, :class, :singleton_class, :clone, :dup, :taint, :tainted?, :untaint, :untrust, :untrusted?, :trust, :freeze, :frozen?, :to_s, :inspect, :methods, :singleton_methods, :protected_methods, :private_methods, :public_methods, :instance_variables, :instance_variable_get, :instance_variable_set, :instance_variable_defined?, :remove_instance_variable, :instance_of?, :kind_of?, :is_a?, :tap, :send, :public_send, :respond_to?, :extend, :display, :method, :public_method, :singleton_method, :define_singleton_method, :object_id, :to_enum, :enum_for, :pretty_inspect, :byebug, :debugger, :==, :equal?, :!, :!=, :instance_eval, :instance_exec, :__send__, :__id__]
(byebug) a.set_client(@client)
#<MMS::Client:0x007fd4b8ae0e40 @username="mms@local.de", @apikey="11a0a7dd-c97c-4c06-ac05-bb814a93dfce", @url="http://mms-dev.lhotse.ov.otto.de/api/public/v1.0">
(byebug) n

[37, 46] in .rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/resource/group.rb
   37:       alert_list = []
   38:       @client.get('/groups/' + @id + '/alerts?status=' + status + '&pageNum=' + page.to_s + '&itemsPerPage=' + limit.to_s).each do |alert|
   39:         a = MMS::Resource::Alert.new
   40:         byebug
   41:         a.set_client(@client)
=> 42:         a.set_group(self)
   43:         a.set_data(data)
   44: 
   45:         alert_list.push a
   46:       end
(byebug) n
.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/resource/group.rb:42:in `block in alerts': undefined method `set_group' for #<MMS::Resource::Alert:0x007fd4b85f4120> (NoMethodError)
	from /home/evalenti/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/resource/group.rb:38:in `each'
	from /home/evalenti/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/resource/group.rb:38:in `alerts'
	from /home/evalenti/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/agent.rb:61:in `block in alerts'
	from /home/evalenti/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/agent.rb:60:in `each'
	from /home/evalenti/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/mms-api-0.1.2/lib/mms/agent.rb:60:in `alerts'
	from check_mms_alerts.rb:38:in `<main>'
