### PR TITLE
Added hashes to restore job

### DIFF
--- a/lib/mms/resource/restore_job.rb
+++ b/lib/mms/resource/restore_job.rb
@@ -23,6 +23,7 @@ module MMS
     attr_accessor :cluster_id
     attr_accessor :group_id
     attr_accessor :host_id
+    attr_accessor :hashes
 
     # @return [MMS::Resource::Cluster]
     def cluster
@@ -89,6 +90,7 @@ module MMS
       @cluster_id = data['clusterId']
       @group_id = data['groupId']
       @host_id = data['hostId']
+      @hashes = data['hashes']
     end
 
     def _to_hash

--- a/lib/mms/resource/restore_job.rb
+++ b/lib/mms/resource/restore_job.rb
@@ -78,6 +78,9 @@ module MMS
     private
 
     def _from_hash(data)
+      puts '--- DEBUG FROM HASH ------------------------------------------------------------'
+      puts data.inspect
+      puts '--- DEBUG FROM HASH ------------------------------------------------------------'
       @snapshot_id = data['snapshotId']
       @created = data['created']
       @status_name = data['statusName']

--- a/lib/mms/resource/restore_job.rb
+++ b/lib/mms/resource/restore_job.rb
@@ -78,9 +78,6 @@ module MMS
     private
 
     def _from_hash(data)
-      puts '--- DEBUG FROM HASH ------------------------------------------------------------'
-      puts data.inspect
-      puts '--- DEBUG FROM HASH ------------------------------------------------------------'
       @snapshot_id = data['snapshotId']
       @created = data['created']
       @status_name = data['statusName']

--- a/lib/mms/version.rb
+++ b/lib/mms/version.rb
@@ -1,3 +1,3 @@
 module MMS
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
Hi,
after the file is downloaded you can retrieve the hashes of the downloaded file to verify the contents (https://docs.opsmanager.mongodb.com/current/reference/api/restore-jobs/).

Would be nice if you could merge it into the version.

Regards
Mike