### PR TITLE
add put

### DIFF
--- a/lib/mms/client.rb
+++ b/lib/mms/client.rb
@@ -39,6 +39,13 @@ module MMS
       _request(Net::HTTP::Patch, @url + path, @username, @apikey, data)
     end
 
+    # @param [String] path
+    # @param [Hash] data
+    # @return [Hash]
+    def put(path, data)
+      _request(Net::HTTP::Put, @url + path, @username, @apikey, data)
+    end
+
     private
 
     # @param [Net::HTTPRequest] http_method


### PR DESCRIPTION
Added the missing `PUT` method. The underlying MMS API uses `PUT` for a few things and it's nice to be able to do `client.put`, `client.get` etc to make direct REST calls for the things not covered by the agent.