### PR TITLE
remove duplicate delete command to avoid 404 rc from api

### DIFF
--- a/lib/mms/agent.rb
+++ b/lib/mms/agent.rb
@@ -95,7 +95,6 @@ module MMS
     # @param [String] hostid
     # @return [TrueClass, FalseClass]
     def host_delete(groupid, hostid)
-      client.delete("/groups/#{groupid}/hosts/#{hostid}")
       host = client.delete("/groups/#{groupid}/hosts/#{hostid}")
       host == {} ? true : false
     end


### PR DESCRIPTION
The duplicate host_delete call caused the error below:
MMS::ApiError: API Response error! Code: 404, body: {"detail":"No host with ID 11111 exists in group 22222.","error":404,"reason":"Not Found"}